### PR TITLE
Widget separator by using extension on iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+coverage

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ In this package, right now we have the following extension methods:
 - **Extensions on num:**
     - SizedBox hSizedBox
     - SizedBox wSizedBox
+    <br>
 - **Extension on Iterable**
     - Iterable<Widget> separator(Widget element)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ In this package, right now we have the following extension methods:
 - **Extensions on num:**
     - SizedBox hSizedBox
     - SizedBox wSizedBox
+- **Extension on Iterable**
+    - Iterable<Widget> separator(Widget element)
 
 ## Contribution Information
 

--- a/lib/src/iterator_extension.dart
+++ b/lib/src/iterator_extension.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+
+extension IterableExt on Iterable<Widget> {
+  Iterable<Widget> separator(Widget element) sync* {
+    final iterator = this.iterator;
+    if (iterator.moveNext()) {
+      yield iterator.current;
+      while (iterator.moveNext()) {
+        yield element;
+        yield iterator.current;
+      }
+    }
+  }
+}

--- a/lib/src/iterator_extension.dart
+++ b/lib/src/iterator_extension.dart
@@ -1,7 +1,21 @@
 import 'package:flutter/widgets.dart';
 
-/// Extension on [Iterable] to add a separator between each widget using generators.
+/// Extension on Iterable to add a separator between each widget using generators.
 extension IterableExt on Iterable<Widget> {
+  ///Add separator widget in between the items.
+  ///It takes [element] as the parameter of type Widget.
+  ///Example to use these in the Column class:
+  ///```
+  ///Column(
+  ///  children: [
+  ///    const Text('T1'),
+  ///    const Text('T2'),
+  ///    const Text('T3'),
+  ///    const Text('T4'),
+  ///  ].separator(const SizedBox(height: 8.0)).toList(),
+  ///);
+  ///```
+  ///
   Iterable<Widget> separator(Widget element) sync* {
     final iterator = this.iterator;
     if (iterator.moveNext()) {

--- a/lib/src/iterator_extension.dart
+++ b/lib/src/iterator_extension.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+/// Extension on [Iterable] to add a separator between each widget using generators.
 extension IterableExt on Iterable<Widget> {
   Iterable<Widget> separator(Widget element) sync* {
     final iterator = this.iterator;

--- a/test/unit_tests/iterator_extension_test.dart
+++ b/test/unit_tests/iterator_extension_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_extensions/src/iterator_extension.dart';
+
+void main() {
+  group('Widget Separator', () {
+    test('No separator if widget list is empty', () async {
+      final widgets = <Widget>[];
+      final result = widgets.separator(const SizedBox()).toList();
+      expect(result.isEmpty, true);
+    });
+
+    test('No separator on one widget', () async {
+      final widgets = [const Text('T1')];
+      final result = widgets.separator(const SizedBox()).toList();
+      expect(result.length, 1);
+      expect(result[0].runtimeType, Text);
+    });
+
+    test('One separator in between two widgets', () async {
+      final widgets = [const Text('T1'), const Text('T2')];
+      final result = widgets.separator(const SizedBox()).toList();
+      expect(result.length, 3);
+      expect(result[0].runtimeType, Text);
+      expect(result[1].runtimeType, SizedBox);
+      expect(result[2].runtimeType, Text);
+    });
+
+    test('Two separator in between three widgets', () async {
+      final widgets = [const Text('T1'), const Text('T2'), const Text('T3')];
+      final result = widgets.separator(const SizedBox()).toList();
+      expect(result.length, 5);
+      expect(result[0].runtimeType, Text);
+      expect(result[1].runtimeType, SizedBox);
+      expect(result[2].runtimeType, Text);
+      expect(result[3].runtimeType, SizedBox);
+      expect(result[4].runtimeType, Text);
+    });
+  });
+}


### PR DESCRIPTION
## Description
Usage in this article [How to Create Separators for Rows and Columns](https://widgettricks.substack.com/p/separators-for-rows-columns)

## Basic Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ Ran `dartdoc`
- [x] 🛠️ Added proper documentation
- [x] ❌ No warnings or errors in the code
- [ ] ✅ If added a new extension, added in Readme and example too
- [x] 🧪 If added a new extension, written proper test cases for it

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


