### PR TITLE
feat: EdgeInset extension on num

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ In this package, right now we have the following extension methods:
 - **Extensions on num:**
     - SizedBox hSizedBox
     - SizedBox wSizedBox
+    - EdgeInsets edgeInsetAll
+    - EdgeInsets edgeInsetHorizontal
+    - EdgeInsets edgeInsetVertical
     <br>
 - **Extension on Iterable**
     - `Iterable<Widget> separator(Widget element)`

--- a/example/lib/extension_examples/context_extension_example.dart
+++ b/example/lib/extension_examples/context_extension_example.dart
@@ -10,59 +10,74 @@ class ContextExtensionExample extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Context Extension Example'),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              onPressed: () {
-                context.showSnackBar(
-                  const SnackBar(
-                    content: Text('Snackbar'),
-                  ),
-                );
-              },
-              child: const Text('Show Snackbar'),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                context.showNewDialog(
-                  const AlertDialog(
-                    title: Text('Dialog'),
-                  ),
-                );
-              },
-              child: const Text('Show Dialog'),
-            ),
-            Text('Screen Height: ${context.screenHeight}'),
-            Text('Screen Width: ${context.screenWidth}'),
-            Text('Screen AspectRatio: ${context.aspectRatio}'),
-            Padding(
-              padding: context.padding,
-              child: const Text('Text wrapped with Screen Padding'),
-            ),
-            Padding(
-              padding: context.viewInsets,
-              child: const Text('Text wrapped with ViewInsets'),
-            ),
-            Padding(
-              padding: context.viewPadding,
-              child: const Text('Text wrapped with View Padding'),
-            ),
-            Text('Is the device mobile?: ${context.isMobile}'),
-            Text('Is the device tablet?: ${context.isTablet}'),
-            Text('Is the device desktop?: ${context.isDesktop}'),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: () {
+                  context.showSnackBar(
+                    const SnackBar(
+                      content: Text('Snackbar'),
+                    ),
+                  );
+                },
+                child: const Text('Show Snackbar'),
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  context.showNewDialog(
+                    const AlertDialog(
+                      title: Text('Dialog'),
+                    ),
+                  );
+                },
+                child: const Text('Show Dialog'),
+              ),
+              Text('Screen Height: ${context.screenHeight}'),
+              Text('Screen Width: ${context.screenWidth}'),
+              Text('Screen AspectRatio: ${context.aspectRatio}'),
+              Padding(
+                padding: context.padding,
+                child: const Text('Text wrapped with Screen Padding'),
+              ),
+              Padding(
+                padding: context.viewInsets,
+                child: const Text('Text wrapped with ViewInsets'),
+              ),
+              Padding(
+                padding: context.viewPadding,
+                child: const Text('Text wrapped with View Padding'),
+              ),
+              Text('Is the device mobile?: ${context.isMobile}'),
+              Text('Is the device tablet?: ${context.isTablet}'),
+              Text('Is the device desktop?: ${context.isDesktop}'),
 
-            /// Example of using the `theme` extension
-            ///
-            Text(
-              "Primary color text and bodyLarge text",
-              style: context.theme.textTheme.bodyLarge,
-            )
-          ].separator(20.hSizedBox).toList(),
-          // Separator from iterator extension and hSizedBox from number extension
+              /// Example of using the `theme` extension
+              ///
+              Text(
+                "Primary color text and bodyLarge text",
+                style: context.theme.textTheme.bodyLarge,
+              ),
+
+              /// Example of EdgeInset extension
+              ///
+              Padding(
+                padding: 8.edgeInsetAll,
+                child: const Text("Text Wrapped with All Side Padding 8"),
+              ),
+
+              Container(
+                margin: 20.edgeInsetHorizontal,
+                child: const Text("Text Wrapped with Horizontal 20 Margin"),
+              )
+            ].separator(20.hSizedBox).toList(),
+
+            // Separator from iterator extension and hSizedBox from number extension
+          ),
         ),
       ),
     );

--- a/lib/src/number_extensions.dart
+++ b/lib/src/number_extensions.dart
@@ -8,4 +8,15 @@ extension NumberExtension on num {
   /// Creates an empty SizedBox with width as the given number.
   ///
   SizedBox get wSizedBox => SizedBox(width: toDouble());
+
+  /// Converts the number to uniform EdgeInsets.
+  EdgeInsets get edgeInsetAll => EdgeInsets.all(toDouble());
+
+  /// Converts the number to symmetric horizontal edgeInset.
+  EdgeInsets get edgeInsetHorizontal =>
+      EdgeInsets.symmetric(horizontal: toDouble());
+
+  /// Converts the number to symmetric vertical edgeInset.
+  EdgeInsets get edgeInsetVertical =>
+      EdgeInsets.symmetric(vertical: toDouble());
 }

--- a/test/unit_tests/super_extensions_unit_test.dart
+++ b/test/unit_tests/super_extensions_unit_test.dart
@@ -125,6 +125,38 @@ void main() {
           expect(box0.height, null);
         },
       );
+      test(
+        'Ensure the edgeInsetAll returns correct uniform edgeInsets',
+        () {
+          final inset = 20.edgeInsetAll;
+          expect(inset.left, 20.0);
+          expect(inset.top, 20.0);
+          expect(inset.right, 20.0);
+          expect(inset.bottom, 20.0);
+        },
+      );
+
+      test(
+        'Ensure the edgeInsetHorizontal returns correct horizontal edgeInsets',
+        () {
+          final inset = 30.edgeInsetHorizontal;
+          expect(inset.left, 30.0);
+          expect(inset.right, 30.0);
+          expect(inset.top, 0.0);
+          expect(inset.bottom, 0.0);
+        },
+      );
+
+      test(
+        'Ensure the edgeInsetVertical returns correct vertical edgeInsets',
+        () {
+          final inset = 15.edgeInsetVertical;
+          expect(inset.top, 15.0);
+          expect(inset.bottom, 15.0);
+          expect(inset.left, 0.0);
+          expect(inset.right, 0.0);
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
## Description

This PR adds an extension method on num to create EdgeInset for padding and margins easily.

## Basic Checklist

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ Ran `dartdoc`
- [x] 🛠️ Added proper documentation
- [x] ❌ No warnings or errors in the code
- [x] ✅ If added a new extension, added in Readme and example too
- [x] 🧪 If added a new extension, written proper test cases for it

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore


